### PR TITLE
merge from branch 23 - 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Stage 1: Build the native executable with Maven and GraalVM
+# Using a base image with Java 21, which has good support for GraalVM native image compilation via Spring Boot 3
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the Maven wrapper and pom.xml to cache dependencies
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+
+# Download dependencies
+RUN ./mvnw dependency:go-offline
+
+# Copy the rest of the source code
+COPY src ./src
+
+# Build the native executable
+# This command uses the 'native' profile, which should be activated in Spring Boot projects.
+# We skip tests as they are not needed for the final artifact.
+RUN ./mvnw native:compile -Pnative -DskipTests
+
+# Stage 2: Create the final, minimal image
+# Using a distroless static image which is very small and secure
+FROM gcr.io/distroless/cc-static
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the native executable from the builder stage
+COPY --from=builder /app/target/spring-project-steganography-tool .
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# Set the entrypoint to run the executable
+ENTRYPOINT ["/app/spring-project-steganography-tool"]

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you wish to run the application directly on your machine's JVM without contai
 1.  **Start the Database**:
     Use Docker Compose to start only the MySQL database service.
     ```bash
-    docker-compose up -d db-mysql
+    docker compose up -d db-mysql
     ```
     This will start a MySQL container, create a `stego` database, and configure a `user`.
 

--- a/README.md
+++ b/README.md
@@ -1,99 +1,124 @@
 # Spring Boot Steganography Tool
 
+![Java](https://img.shields.io/badge/Java-25-blue.svg)
+![Spring Boot](https://img.shields.io/badge/Spring_Boot-3.x-brightgreen.svg)
+![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)
+
 This project is a powerful and secure steganography tool built with Spring Boot 3. It allows you to hide text messages or files within images using the Least Significant Bit (LSB) technique. The application provides a RESTful API for all its operations, supports robust AES-256 encryption for hidden data, and includes features like large file streaming to ensure memory efficiency.
 
 ## Table of Contents
 
+- [What is Steganography?](#what-is-steganography)
 - [Features](#features)
 - [How It Works](#how-it-works)
   - [Encoding Process](#encoding-process)
   - [Decoding Process](#decoding-process)
+  - [Security Model](#security-model)
 - [Technology Stack](#technology-stack)
 - [API Endpoints](#api-endpoints)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Cloning the Repository](#cloning-the-repository)
   - [Configuration](#configuration)
-  - [Running the Application](#running-the-application)
+  - [Running the Application (JVM)](#running-the-application-jvm)
 - [Interacting with the API](#interacting-with-the-api)
-  - [Example 1: Encode a Text Message](#example-1-encode-a-text-message)
-  - [Example 2: Decode a Stego Image](#example-2-decode-a-stego-image)
+  - [Example 1: Estimate Capacity](#example-1-estimate-capacity)
+  - [Example 2: Encode a Text Message](#example-2-encode-a-text-message)
+  - [Example 3: Encode a File](#example-3-encode-a-file)
+  - [Example 4: Decode a Stego Image](#example-4-decode-a-stego-image)
+- [Building for Production](#building-for-production)
+  - [Building a JAR](#building-a-jar)
+  - [Building a Native Executable](#building-a-native-executable)
+- [Containerization with Docker (Native Image)](#containerization-with-docker-native-image)
 - [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [License](#license)
+
+## What is Steganography?
+
+Steganography is the practice of concealing a message, image, or file within another message, image, or file. Unlike cryptography, which obscures the content of a message, steganography conceals the very existence of the message. This tool uses the **Least Significant Bit (LSB)** method, which subtly alters the color data of image pixels to embed information, making the changes virtually invisible to the human eye.
 
 ## Features
 
 - **Text & File Steganography**: Embed both plain text and binary files within images.
 - **Strong Encryption**: All hidden data is encrypted with **AES-256 (CBC mode)** using a key derived from your password via **PBKDF2**.
 - **RESTful API**: Easy-to-use endpoints for encoding, decoding, capacity estimation, and managing encodings.
+- **GraalVM Native Image Support**: Includes a multi-stage `Dockerfile` to build a lightweight, fast-starting native executable.
 - **Capacity Estimation**: Before performing an expensive encoding operation, you can estimate if your data will fit in a given image.
 - **Large File Streaming**: Efficiently encodes large files by streaming them, keeping memory usage low. A configurable threshold (`app.stream.threshold-bytes`) determines when to switch to streaming.
 - **Database Integration**: Metadata about each encoding (e.g., file names, sizes) is saved to a MySQL database using Spring Data JPA.
 - **Virtual Threads**: The application is configured to use Java 21+ Virtual Threads with an embedded Jetty server for high-concurrency request handling.
 - **Scheduled Cleanup**: A background task runs periodically to clean up orphaned stego files from storage and expired extracted files.
+- **Docker Support**: Comes with a `Dockerfile` and `compose.yml` for easy setup and deployment.
 
 ## How It Works
 
-The application uses the Least Significant Bit (LSB) steganography method. It modifies the least significant bits of the color channels (Red, Green, Blue) in an image's pixels to store data. The changes are so subtle that they are virtually invisible to the human eye.
+The application embeds data by modifying the least significant bits of an image's pixel color channels (Red, Green, Blue).
 
 ### Encoding Process
 
-1.  **Input**: The user provides a cover image, the data to hide (text or a file), and a password.
-2.  **Encryption**: The data is encrypted using AES-256. The encryption key is derived from the user's password and a random salt using the PBKDF2 algorithm. This ensures that the same password always produces a different key for different encryptions, enhancing security.
-3.  **Metadata Creation**: A JSON metadata block is created containing essential information for decoding:
+1.  **Input**: A user provides a cover image, the data to hide (text or a file), and a password.
+2.  **Encryption**: The data is encrypted using AES-256.
+3.  **Metadata Creation**: A JSON metadata block is created containing:
     -   `lsbDepth`: The number of LSBs to use per color channel (1 or 2).
     -   `hasText` / `hasFile`: A flag indicating the type of hidden data.
-    -   `encryptionKeyHash`: A **SHA-256 hash** of the encryption key. This is used during decoding to quickly verify the password without exposing the key itself.
-    -   `nameOfFileToEmbed`: The original filename if a file is being embedded.
+    -   `encryptionKeyHash`: A **SHA-256 hash** of the encryption key for password verification.
+    -   `nameOfFileToEmbed`: The original filename if embedding a file.
 4.  **LSB Embedding**: The data is written into the cover image's pixels in a specific format:
-    -   First, a 4-byte "magic number" (`STEG`) and a version byte are written at LSB depth 1. This helps identify images processed by this tool.
-    -   Next, the length of the metadata, the metadata JSON itself, and the length of the encrypted payload are written.
+    -   A 4-byte "magic number" (`STEG`) and a version byte identify images processed by this tool.
+    -   The metadata, its length, and the encrypted payload's length are written.
     -   Finally, the encrypted payload is written using the user-specified LSB depth.
-5.  **Output**: The modified image is saved as a new, lossless **PNG file** to the configured storage directory, and its metadata is persisted in the database.
+5.  **Output**: The modified image is saved as a new, lossless **PNG file**, and its metadata is persisted in the database.
 
 ### Decoding Process
 
-1.  **Input**: The user provides the stego-image and the password used for encoding.
-2.  **Metadata Extraction**: The application reads the image's LSBs to find the "magic number" and version. If valid, it extracts the full metadata block.
-3.  **Password Verification**: It hashes the provided password and compares it to the `encryptionKeyHash` stored in the metadata. If the hashes do not match, the process is aborted.
-4.  **Payload Extraction**: Using the payload length and LSB depth from the metadata, the application reads the raw encrypted data from the image's pixels.
-5.  **Decryption**: The extracted payload is decrypted using the user's password.
-6.  **Output**: The original data is returned. If it's text, the message is provided directly. If it's a file, it is saved to a temporary location, and its path is returned. The temporary file is automatically deleted after a configured TTL (`app.extraction.temp-ttl-ms`).
+1.  **Input**: A user provides the stego-image and the password.
+2.  **Metadata Extraction**: The application reads the image's LSBs to find the "magic number" and extracts the metadata.
+3.  **Password Verification**: It hashes the provided password and compares it to the `encryptionKeyHash` from the metadata. If they don't match, the process fails.
+4.  **Payload Extraction**: The application reads the raw encrypted data from the image's pixels.
+5.  **Decryption**: The payload is decrypted using the user's password.
+6.  **Output**: If text, the message is returned. If a file, it's saved to a temporary location, and its path is returned. Temporary files are deleted automatically after a configured TTL.
+
+### Security Model
+
+- **Password Derivation**: The AES key is derived from the user's password and a unique, random **16-byte salt** using **PBKDF2 with 65,536 iterations**. This salt is stored with the encrypted data, ensuring that even identical passwords produce different keys for different encodings.
+- **Password Verification**: During decoding, the provided password is used to derive a key, which is then hashed (SHA-256) and compared against the hash stored in the image's metadata. This prevents incorrect password attempts without decrypting the entire payload and avoids storing the password or key directly.
+- **Authenticated Encryption**: The use of **CBC mode with PKCS5Padding** and a unique **16-byte Initialization Vector (IV)** ensures that encrypted data is resistant to common cryptographic attacks.
 
 ## Technology Stack
 
 - **Java 25** & **Spring Boot 3**
+- **GraalVM**: For building a native executable.
 - **Spring Web, Data JPA, Jetty**
 - **MySQL**: Database for persisting encoding metadata.
 - **Lombok**: To reduce boilerplate code.
 - **MapStruct**: For high-performance DTO-entity mapping.
 - **Maven**: For project and dependency management.
-- **Docker & Docker Compose**: For easy database setup.
+- **Docker & Docker Compose**: For easy database setup and application containerization.
 
 ## API Endpoints
 
-The following are the main endpoints provided by the application. The base path is `/api/v1/stego`.
+The base path for all endpoints is `/api/v1/stego`.
 
-| Method | Endpoint                    | Description                                                                                             |
-| :----- | :-------------------------- | :------------------------------------------------------------------------------------------------------ |
-| `GET`  | `/estimate`                 | Estimates the data capacity of an image based on its dimensions, LSB depth, and payload size.           |
-| `POST` | `/encode/text`              | Encodes a text message into a cover image.                                                              |
-| `POST` | `/encode/file`              | Encodes a file into a cover image. Handles both in-memory and streaming based on file size.             |
-| `POST` | `/decode`                   | Decodes a message or file from a stego-image using a password.                                          |
-| `POST` | `/metadata`                 | Extracts and returns steganography metadata from an image without decoding the payload.                 |
-| `GET`  | `/encodings`                | Lists all steganography encodings stored in the database.                                               |
-| `GET`  | `/encodings/{id}`           | Retrieves a specific encoding by its UUID.                                                              |
-| `DELETE`| `/encodings/{id}`          | Deletes an encoding record from the database and the corresponding stego file from storage.              |
+| Method   | Endpoint          | Description                                                                                 |
+| :------- | :---------------- | :------------------------------------------------------------------------------------------ |
+| `GET`    | `/estimate`       | Estimates the data capacity of an image based on dimensions, LSB depth, and payload size.   |
+| `POST`   | `/encode/text`    | Encodes a text message into a cover image.                                                  |
+| `POST`   | `/encode/file`    | Encodes a file into a cover image. Handles both in-memory and streaming based on file size. |
+| `POST`   | `/decode`         | Decodes a message or file from a stego-image using a password.                              |
+| `POST`   | `/metadata`       | Extracts and returns steganography metadata from an image without decoding the payload.     |
+| `GET`    | `/encodings`      | Lists all steganography encodings stored in the database.                                   |
+| `GET`    | `/encodings/{id}` | Retrieves a specific encoding by its UUID.                                                  |
+| `DELETE` | `/encodings/{id}` | Deletes an encoding record and the corresponding stego file from storage.                   |
 
 ## Getting Started
-
-Follow these steps to clone and run the project on your local machine.
 
 ### Prerequisites
 
 - **JDK 21 or higher** (The project is configured for Java 25).
 - **Maven 3.8+**.
-- **Docker and Docker Compose** (for running the MySQL database).
-- A REST client like [Postman](https://www.postman.com/) or `curl` to interact with the API.
+- **Docker and Docker Compose** (for running the MySQL database and the application).
+- A REST client like [Postman](https://www.postman.com/) or `curl`.
 
 ### Cloning the Repository
 
@@ -104,21 +129,25 @@ cd spring-project-steganography-tool
 
 ### Configuration
 
-The main configuration is in `src/main/resources/application.yml`. The default settings are configured to work with the provided Docker Compose setup.
+The main configuration is in `src/main/resources/application.yml`. The default settings are designed to work with the provided Docker Compose setup.
 
-Key properties:
-- `spring.datasource.*`: Configures the connection to the MySQL database.
-- `app.storage.base-path`: The local directory where stego-images and extracted files will be stored. Defaults to `storage/`.
-- `app.cleanup.*`: Settings for the scheduled file cleanup task.
-- `app.stream.threshold-bytes`: File size (in bytes) above which streaming encoding is used. Defaults to 1MB.
-- `app.extraction.temp-ttl-ms`: Time-to-live for extracted files. Defaults to 5 minutes.
+| Property                        | Description                                                              | Default Value |
+| :------------------------------ | :----------------------------------------------------------------------- | :------------ |
+| `spring.datasource.*`           | Configures the connection to the MySQL database.                         | (See file)    |
+| `app.storage.base-path`         | Local directory where stego-images and extracted files will be stored.   | `storage/`    |
+| `app.cleanup.enabled`           | Enables the scheduled file cleanup task.                                 | `true`        |
+| `app.cleanup.interval-ms`       | Interval for the cleanup task.                                           | `120000` (2m) |
+| `app.stream.threshold-bytes`    | File size (in bytes) above which streaming encoding is used.             | `1000000` (1MB) |
+| `app.extraction.temp-ttl-ms`    | Time-to-live for extracted files.                                        | `300000` (5m) |
 
-### Running the Application
+### Running the Application (JVM)
+
+If you wish to run the application directly on your machine's JVM without containerization:
 
 1.  **Start the Database**:
-    Use Docker Compose to start the MySQL database service.
+    Use Docker Compose to start only the MySQL database service.
     ```bash
-    docker-compose up -d
+    docker-compose up -d db-mysql
     ```
     This will start a MySQL container, create a `stego` database, and configure a `user`.
 
@@ -127,51 +156,129 @@ Key properties:
     ```bash
     ./mvnw spring-boot:run
     ```
-    The application will start and connect to the database. By default, the server runs on port `8080`.
+    The application will start on port `8080`.
 
 ## Interacting with the API
 
-Here are a few examples using `curl`.
+### Example 1: Estimate Capacity
 
-### Example 1: Encode a Text Message
+Check if a 10KB message fits in a 1920x1080 image using LSB depth 1.
 
-This command encodes the message "Hello, World!" into `cover.png` with the password "secret".
+**Request:**
+```bash
+curl "http://localhost:8080/api/v1/stego/estimate?width=1920&height=1080&lsbDepth=1&plainLength=10240"
+```
 
+**Response:**
+```json
+{
+    "capacityBytes": 777600,
+    "overheadBytes": 137,
+    "encryptedBytesEstimate": 10256,
+    "requiredBytesEstimate": 10393,
+    "fits": true,
+    "streamThresholdBytes": 1000000
+}
+```
+
+### Example 2: Encode a Text Message
+
+Encode the message "Secret message" into `cover.png` with password "secure_password".
+
+**Request:**
 ```bash
 curl -X POST http://localhost:8080/api/v1/stego/encode/text \
   -F "coverImage=@/path/to/your/cover.png" \
-  -F "message=Hello, World!" \
-  -F "password=secret" \
+  -F "message=Secret message" \
+  -F "password=secure_password" \
   -F "lsbDepth=1"
 ```
 
-The API will return a JSON response with details of the newly created stego-image, including its filename and UUID.
+### Example 3: Encode a File
 
-### Example 2: Decode a Stego Image
+Encode `document.pdf` into `image.png` with the same password.
 
-This command decodes the data from `stego-image.png` using the password "secret".
+**Request:**
+```bash
+curl -X POST http://localhost:8080/api/v1/stego/encode/file \
+  -F "coverImage=@/path/to/your/image.png" \
+  -F "fileToEmbed=@/path/to/your/document.pdf" \
+  -F "password=secure_password" \
+  -F "lsbDepth=2"
+```
 
+### Example 4: Decode a Stego Image
+
+Decode `stego-image.png` using the password "secure_password".
+
+**Request:**
 ```bash
 curl -X POST http://localhost:8080/api/v1/stego/decode \
   -F "stegoImage=@/path/to/your/stego-image.png" \
-  -F "password=secret"
+  -F "password=secure_password"
 ```
 
-The API will return the hidden data. If it's text, the JSON will contain the message. If it's a file, it will contain the path to the temporarily extracted file.
+## Building for Production
+
+### Building a JAR
+
+You can build the project into an executable JAR file using Maven.
+
+```bash
+./mvnw clean package
+```
+The JAR file will be created in the `target/` directory.
+
+### Building a Native Executable
+
+You can compile the application into a self-contained native executable using the GraalVM native image plugin.
+
+```bash
+# This requires a GraalVM-enabled JDK and can take several minutes.
+./mvnw native:compile -Pnative
+```
+The executable will be created in the `target/` directory.
+
+## Containerization with Docker (Native Image)
+
+The recommended way to run the application in production is to build a minimal Docker container with a GraalVM native executable.
+
+The provided `compose.yml` is configured to build and run both the application and its database.
+
+1.  **Build and Run with Docker Compose:**
+    This single command will:
+    -   Build the native executable inside a Docker container.
+    -   Create a minimal, production-ready Docker image.
+    -   Start the application container and the MySQL database container.
+
+    ```bash
+    docker-compose up --build
+    ```
+    The application will be available on port `8080`. The `storage` directory is mounted as a volume, so your files will persist between container restarts.
+
+2.  **Stopping the services:**
+    To stop the containers, press `Ctrl+C` or run:
+    ```bash
+    docker-compose down
+    ```
 
 ## Project Structure
-
-The project follows a standard Spring Boot structure, with a clear separation of concerns.
 
 - `configs/`: Spring configuration classes (e.g., `VirtualThreadConfig`).
 - `controllers/`: REST controllers that handle API requests (`StegoController`).
 - `entities/`: JPA entity classes (`StegoData`).
 - `exceptions/`: Custom exception classes and a global exception handler.
 - `mappers/`: MapStruct interfaces for DTO-entity conversions.
-- `models/`: DTOs (Data Transfer Objects) used for API requests and responses.
+- `models/`: DTOs (Data Transfer Objects) for API requests and responses.
 - `repos/`: Spring Data JPA repositories (`StegoDataRepository`).
 - `services/`: Business logic, split into interfaces and implementations.
 - `cleanup/`: Contains the `OrphanCleanupTask` for scheduled jobs.
 - `filters/`: Servlet filters like `CorrelationIdFilter` for adding a trace ID to logs.
 
----
+## Contributing
+
+Contributions are welcome! Please fork the repository, create a feature branch, and open a pull request.
+
+## License
+
+This project is licensed under the **GNU Affero General Public License v3.0**. See the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -252,14 +252,14 @@ The provided `compose.yml` is configured to build and run both the application a
     -   Start the application container and the MySQL database container.
 
     ```bash
-    docker-compose up --build
+    docker compose up --build
     ```
     The application will be available on port `8080`. The `storage` directory is mounted as a volume, so your files will persist between container restarts.
 
 2.  **Stopping the services:**
     To stop the containers, press `Ctrl+C` or run:
     ```bash
-    docker-compose down
+    docker compose down
     ```
 
 ## Project Structure

--- a/compose.yml
+++ b/compose.yml
@@ -1,18 +1,39 @@
 services:
-    db-mysql:
-        image: mysql:latest
-        container_name: db-mysql
-        ports:
-            - "3306:3306"
-        environment:
-            - MYSQL_ROOT_PASSWORD=password
-            - MYSQL_DATABASE=stego
-            - MYSQL_USER=user
-            - MYSQL_PASSWORD=password
-        volumes:
-            - mysql_data:/var/lib/mysql
+  # Application Service (builds from Dockerfile)
+  app:
+    build: .
+    container_name: stego-app
+    ports:
+      - "8080:8080"
+    environment:
+      # Connect to the MySQL container
+      - DATABASE_URL=jdbc:mysql://db-mysql:3306/stego
+      - DATABASE_USER=user
+      - DATABASE_PASSWORD=password
+      # Point storage inside the container to the mounted volume
+      - STORAGE_BASE_PATH=/app/storage
+    volumes:
+      # Mount the local storage directory into the container to persist files
+      - storage_data:/app/storage
+    depends_on:
+      - db-mysql
+
+  # Database Service
+  db-mysql:
+    image: mysql:latest
+    container_name: db-mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=stego
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=password
+    volumes:
+      - mysql_data:/var/lib/mysql
 
 volumes:
-    mysql_data:
-        driver: local
-        
+  mysql_data:
+    driver: local
+  storage_data:
+    driver: local


### PR DESCRIPTION
This pull request introduces production-ready containerization and significantly enhances the documentation for the Spring Boot Steganography Tool. The main additions are a multi-stage `Dockerfile` for building a GraalVM native executable, a `compose.yml` for orchestrating the app and database with Docker Compose, and a comprehensive update to the `README.md` covering new features, usage examples, and deployment instructions.

**Containerization and Deployment:**

* Added a multi-stage `Dockerfile` that builds a GraalVM native executable with Maven and produces a minimal, secure runtime image using distroless as the base.
* Introduced a `compose.yml` file that defines both the application (built from the Dockerfile) and the MySQL database, with proper environment variables, persistent storage, and service dependencies. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R2-R21) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L18-R39)

**Documentation Improvements:**

* Major expansion of `README.md`:
  * Added technology badges, a new "What is Steganography?" section, and a detailed security model explanation.
  * Updated and clarified the feature list, highlighting GraalVM native image and Docker support.
  * Improved API documentation, configuration instructions, and provided step-by-step guides for building, running, and interacting with the application (both on JVM and via Docker). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R150) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R284)
  * Added new usage examples for capacity estimation, text/file encoding, and decoding.
  * Included clear project structure, contributing guidelines, and license information.

**Configuration and Usability:**

* Clarified and tabulated configuration options in the documentation, making it easier for users to understand and modify settings.
* Provided explicit instructions for running the application in both development (JVM) and production (native Docker image) environments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R150) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R284)

These changes make the project much easier to deploy, use, and contribute to, while also offering a more professional and production-ready setup.

**References:** [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R37) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R2-R21) [[3]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L18-R39) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R121) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R150) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R284)